### PR TITLE
feat: [PIDM-1773] migrate update session payment methods service

### DIFF
--- a/api-spec/v1/api.yaml
+++ b/api-spec/v1/api.yaml
@@ -256,6 +256,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+    patch:
+      tags:
+        - payment-methods-handler
+      operationId: updateSession
+      summary: Update a payment method session
+      description: |-
+        Associates a transaction ID to an existing NPG session identified by payment method ID and order ID.
+        Returns 204 No Content on success.
+      parameters:
+        - name: id
+          in: path
+          description: Payment Method ID
+          required: true
+          schema:
+            $ref: '#/components/schemas/PaymentMethodId'
+        - name: orderId
+          in: path
+          description: Order id related to NPG session
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: X-Client-Id
+          required: true
+          description: Transaction origin (populated by APIM policy)
+          schema:
+            $ref: '#/components/schemas/SessionClientId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchSessionRequest'
+      responses:
+        '204':
+          description: Session successfully updated
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '404':
+          description: Session or payment method not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '409':
+          description: Session already associated to a different transaction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '500':
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
 components:
   schemas:
     PaymentMethodId:
@@ -581,6 +647,15 @@ components:
         title:
           description: Problem title
           type: string
+    PatchSessionRequest:
+      type: object
+      description: Request body for updating a payment method session
+      required:
+        - transactionId
+      properties:
+        transactionId:
+          type: string
+          description: Transaction ID to associate with the session
     SessionPaymentMethodResponse:
       type: object
       description: Session Payment method Response

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/exception/SessionAlreadyAssociatedToTransactionException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/exception/SessionAlreadyAssociatedToTransactionException.kt
@@ -1,0 +1,11 @@
+package it.pagopa.ecommerce.payment.methods.exception
+
+class SessionAlreadyAssociatedToTransactionException(
+    orderId: String,
+    existingTransactionId: String,
+    requestedTransactionId: String,
+) :
+    RuntimeException(
+        "Session for orderId [$orderId] is already associated to transaction [$existingTransactionId], " +
+            "cannot associate to [$requestedTransactionId]"
+    )

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/resource/v1/PaymentMethodsHandlerResource.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/resource/v1/PaymentMethodsHandlerResource.kt
@@ -5,11 +5,13 @@ import it.pagopa.ecommerce.payment.methods.exception.NpgResponseException
 import it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException
 import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodNotFoundException
 import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodsClientException
+import it.pagopa.ecommerce.payment.methods.exception.SessionAlreadyAssociatedToTransactionException
 import it.pagopa.ecommerce.payment.methods.exception.UniqueIdGenerationException
 import it.pagopa.ecommerce.payment.methods.services.PaymentMethodService
 import it.pagopa.ecommerce.payment.methods.v1.server.api.PaymentMethodsApi
 import it.pagopa.ecommerce.payment.methods.v1.server.model.ClientId
 import it.pagopa.ecommerce.payment.methods.v1.server.model.CreateSessionResponse
+import it.pagopa.ecommerce.payment.methods.v1.server.model.PatchSessionRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodResponse
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsResponse
@@ -64,6 +66,17 @@ constructor(private val paymentMethodService: PaymentMethodService) : PaymentMet
     ): CompletionStage<SessionPaymentMethodResponse> {
         return paymentMethodService
             .getCardDataInformation(id, orderId, xClientId.toString())
+            .subscribeAsCompletionStage()
+    }
+
+    override fun updateSession(
+        id: String,
+        orderId: String,
+        xClientId: @NotNull it.pagopa.ecommerce.payment.methods.v1.server.model.SessionClientId,
+        patchSessionRequest: PatchSessionRequest,
+    ): CompletionStage<Void> {
+        return paymentMethodService
+            .updateSession(id, orderId, patchSessionRequest, xClientId.toString())
             .subscribeAsCompletionStage()
     }
 
@@ -155,6 +168,18 @@ constructor(private val paymentMethodService: PaymentMethodService) : PaymentMet
     ): RestResponse<ProblemJson> {
         log.info("Order ID Not Found: {}", exception.message)
         return problemResponse(Response.Status.NOT_FOUND, "Not Found", exception.message.orEmpty())
+    }
+
+    @ServerExceptionMapper
+    fun mapSessionAlreadyAssociatedToTransactionException(
+        exception: SessionAlreadyAssociatedToTransactionException
+    ): RestResponse<ProblemJson> {
+        log.error("Session Already Associated To Transaction: {}", exception.message)
+        return problemResponse(
+            Response.Status.CONFLICT,
+            "Session already associated to transaction",
+            exception.message.orEmpty(),
+        )
     }
 
     private fun problemResponse(

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodService.kt
@@ -2,6 +2,7 @@ package it.pagopa.ecommerce.payment.methods.services
 
 import io.smallrye.mutiny.Uni
 import it.pagopa.ecommerce.payment.methods.v1.server.model.CreateSessionResponse
+import it.pagopa.ecommerce.payment.methods.v1.server.model.PatchSessionRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodResponse
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsResponse
@@ -31,4 +32,11 @@ interface PaymentMethodService {
         orderId: String,
         xClientId: String,
     ): Uni<SessionPaymentMethodResponse>
+
+    fun updateSession(
+        paymentMethodId: String,
+        orderId: String,
+        patchSessionRequest: PatchSessionRequest,
+        xClientId: String,
+    ): Uni<Void>
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
@@ -10,6 +10,7 @@ import it.pagopa.ecommerce.payment.methods.config.SessionUrlConfig
 import it.pagopa.ecommerce.payment.methods.domain.CardDataDocument
 import it.pagopa.ecommerce.payment.methods.domain.NpgSessionDocument
 import it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException
+import it.pagopa.ecommerce.payment.methods.exception.SessionAlreadyAssociatedToTransactionException
 import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionsRedisWrapper
 import it.pagopa.ecommerce.payment.methods.mappers.toPaymentMethodRequestDto
 import it.pagopa.ecommerce.payment.methods.mappers.toPaymentMethodResponse
@@ -18,6 +19,7 @@ import it.pagopa.ecommerce.payment.methods.utils.UniqueIdGenerator
 import it.pagopa.ecommerce.payment.methods.v1.server.model.CardFormFields
 import it.pagopa.ecommerce.payment.methods.v1.server.model.CreateSessionResponse
 import it.pagopa.ecommerce.payment.methods.v1.server.model.Field
+import it.pagopa.ecommerce.payment.methods.v1.server.model.PatchSessionRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.NpgBuildFormParams
 import it.pagopa.ecommerce.payment.methods.v1.server.model.NpgSessionUrls
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodResponse
@@ -296,6 +298,65 @@ constructor(
                                 brand = cardData.circuit
                             }
                         }
+                }
+            }
+    }
+
+    override fun updateSession(
+        paymentMethodId: String,
+        orderId: String,
+        patchSessionRequest: PatchSessionRequest,
+        xClientId: String,
+    ): Uni<Void> {
+        log.info(
+            "[Payment Method handler] Update session for paymentMethodId: {} and orderId: {}",
+            paymentMethodId,
+            orderId,
+        )
+
+        val xRequestId = UUID.randomUUID().toString()
+
+        return restClient
+            .getPaymentMethod(paymentMethodId, xRequestId, xClientId)
+            .flatMap { npgSessionsRedisWrapper.findById(orderId) }
+            .onItem()
+            .ifNull()
+            .failWith { OrderIdNotFoundException(orderId) }
+            .flatMap { session ->
+                val existingTransactionId = session!!.transactionId
+                val requestedTransactionId = patchSessionRequest.transactionId
+
+                if (
+                    existingTransactionId != null && existingTransactionId != requestedTransactionId
+                ) {
+                    log.error(
+                        "Session's transaction id ({}) differs from requested transaction id ({})",
+                        existingTransactionId,
+                        requestedTransactionId,
+                    )
+                    Uni.createFrom()
+                        .failure(
+                            SessionAlreadyAssociatedToTransactionException(
+                                orderId,
+                                existingTransactionId,
+                                requestedTransactionId,
+                            )
+                        )
+                } else if (existingTransactionId != null) {
+                    // Transaction already associated to session (retry case), no-op
+                    Uni.createFrom().voidItem()
+                } else {
+                    // Associate transaction to session
+                    val updatedDocument =
+                        NpgSessionDocument(
+                            orderId = session.orderId,
+                            correlationId = session.correlationId,
+                            sessionId = session.sessionId,
+                            securityToken = session.securityToken,
+                            cardData = session.cardData,
+                            transactionId = requestedTransactionId,
+                        )
+                    npgSessionsRedisWrapper.save(updatedDocument).replaceWithVoid()
                 }
             }
     }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
@@ -19,9 +19,9 @@ import it.pagopa.ecommerce.payment.methods.utils.UniqueIdGenerator
 import it.pagopa.ecommerce.payment.methods.v1.server.model.CardFormFields
 import it.pagopa.ecommerce.payment.methods.v1.server.model.CreateSessionResponse
 import it.pagopa.ecommerce.payment.methods.v1.server.model.Field
-import it.pagopa.ecommerce.payment.methods.v1.server.model.PatchSessionRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.NpgBuildFormParams
 import it.pagopa.ecommerce.payment.methods.v1.server.model.NpgSessionUrls
+import it.pagopa.ecommerce.payment.methods.v1.server.model.PatchSessionRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodResponse
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsResponse

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
@@ -9,6 +9,8 @@ import it.pagopa.ecommerce.payment.methods.domain.NpgSessionDocument
 import it.pagopa.ecommerce.payment.methods.exception.JwtIssuerResponseException
 import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodNotFoundException
 import it.pagopa.ecommerce.payment.methods.exception.PaymentMethodsClientException
+import it.pagopa.ecommerce.payment.methods.exception.SessionAlreadyAssociatedToTransactionException
+import it.pagopa.ecommerce.payment.methods.v1.server.model.PatchSessionRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodResponse
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsRequest
 import it.pagopa.ecommerce.payment.methods.v1.server.model.PaymentMethodsResponse
@@ -961,6 +963,91 @@ class PaymentMethodsClientTest {
 
         assertThrows<PaymentMethodNotFoundException> {
             service.getCardDataInformation("pm-001", testOrderId, "CHECKOUT").await().indefinitely()
+        }
+
+        verify(mockNpgSessionsRedis, times(0)).findById(any())
+    }
+
+    // --- updateSession tests ---
+
+    @Test
+    fun `should associate transactionId to session when no transactionId exists`() {
+        val patchRequest = PatchSessionRequest().apply { transactionId = "tx-001" }
+
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().item(testSessionDocument))
+        whenever(mockNpgSessionsRedis.save(any()))
+            .thenReturn(Uni.createFrom().item(testSessionDocument))
+
+        assertDoesNotThrow {
+            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+        }
+
+        verify(mockNpgSessionsRedis).save(any())
+    }
+
+    @Test
+    fun `should be no-op when transactionId already matches`() {
+        val patchRequest = PatchSessionRequest().apply { transactionId = "tx-001" }
+        val sessionWithTransaction = testSessionDocument.copy(transactionId = "tx-001")
+
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().item(sessionWithTransaction))
+
+        assertDoesNotThrow {
+            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+        }
+
+        // Should NOT save since it's a retry with same transactionId
+        verify(mockNpgSessionsRedis, times(0)).save(any())
+    }
+
+    @Test
+    fun `should throw SessionAlreadyAssociatedToTransactionException when transactionId conflicts`() {
+        val patchRequest = PatchSessionRequest().apply { transactionId = "tx-002" }
+        val sessionWithDifferentTransaction = testSessionDocument.copy(transactionId = "tx-001")
+
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().item(sessionWithDifferentTransaction))
+
+        assertThrows<SessionAlreadyAssociatedToTransactionException> {
+            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+        }
+
+        verify(mockNpgSessionsRedis, times(0)).save(any())
+    }
+
+    @Test
+    fun `should throw OrderIdNotFoundException when session not found for updateSession`() {
+        val patchRequest = PatchSessionRequest().apply { transactionId = "tx-001" }
+
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().nullItem())
+
+        assertThrows<it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException> {
+            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+        }
+    }
+
+    @Test
+    fun `should throw PaymentMethodNotFoundException when payment method does not exist for updateSession`() {
+        val patchRequest = PatchSessionRequest().apply { transactionId = "tx-001" }
+
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(
+                Uni.createFrom().failure(PaymentMethodNotFoundException("Payment method not found"))
+            )
+
+        assertThrows<PaymentMethodNotFoundException> {
+            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
         }
 
         verify(mockNpgSessionsRedis, times(0)).findById(any())

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
@@ -982,7 +982,10 @@ class PaymentMethodsClientTest {
             .thenReturn(Uni.createFrom().item(testSessionDocument))
 
         assertDoesNotThrow {
-            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+            service
+                .updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT")
+                .await()
+                .indefinitely()
         }
 
         verify(mockNpgSessionsRedis).save(any())
@@ -999,7 +1002,10 @@ class PaymentMethodsClientTest {
             .thenReturn(Uni.createFrom().item(sessionWithTransaction))
 
         assertDoesNotThrow {
-            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+            service
+                .updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT")
+                .await()
+                .indefinitely()
         }
 
         // Should NOT save since it's a retry with same transactionId
@@ -1017,7 +1023,10 @@ class PaymentMethodsClientTest {
             .thenReturn(Uni.createFrom().item(sessionWithDifferentTransaction))
 
         assertThrows<SessionAlreadyAssociatedToTransactionException> {
-            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+            service
+                .updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT")
+                .await()
+                .indefinitely()
         }
 
         verify(mockNpgSessionsRedis, times(0)).save(any())
@@ -1029,11 +1038,13 @@ class PaymentMethodsClientTest {
 
         whenever(mockClient.getPaymentMethod(any(), any(), any()))
             .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
-        whenever(mockNpgSessionsRedis.findById(testOrderId))
-            .thenReturn(Uni.createFrom().nullItem())
+        whenever(mockNpgSessionsRedis.findById(testOrderId)).thenReturn(Uni.createFrom().nullItem())
 
         assertThrows<it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException> {
-            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+            service
+                .updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT")
+                .await()
+                .indefinitely()
         }
     }
 
@@ -1047,7 +1058,10 @@ class PaymentMethodsClientTest {
             )
 
         assertThrows<PaymentMethodNotFoundException> {
-            service.updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT").await().indefinitely()
+            service
+                .updateSession("pm-001", testOrderId, patchRequest, "CHECKOUT")
+                .await()
+                .indefinitely()
         }
 
         verify(mockNpgSessionsRedis, times(0)).findById(any())


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Migrated `updateSession` (PATCH `/payment-methods/{id}/sessions/{orderId}`) from `pagopa-ecommerce-payment-methods-service` to `pagopa-ecommerce-payment-methods-handler`

#### Motivation and Context

This is part of the migration effort to move payment method session management endpoints from the old `pagopa-ecommerce-payment-methods-service` to this handler. The `updateSession` endpoint allows the transaction service to associate a `transactionId` to an existing NPG session stored in Redis.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.