### PR TITLE
feat: [PIDM-1774] migrate getTransactionIdForSession from payment methods service

### DIFF
--- a/api-spec/v1/api.yaml
+++ b/api-spec/v1/api.yaml
@@ -322,6 +322,71 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemJson'
+  /payment-methods/{id}/sessions/{orderId}/transactionId:
+    get:
+      tags:
+        - payment-methods-handler
+      operationId: getTransactionIdForSession
+      summary: Get eCommerce transaction id for the given NPG session
+      description: |-
+        API to get a transaction id from a NPG session.
+        Validates the session security token provided via Authorization Bearer header.
+      parameters:
+        - name: id
+          in: path
+          description: Payment Method ID
+          required: true
+          schema:
+            $ref: '#/components/schemas/PaymentMethodId'
+        - name: orderId
+          in: path
+          description: Order id related to NPG session
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Authorization
+          required: true
+          description: Bearer security token for session validation
+          schema:
+            type: string
+        - in: header
+          name: X-Client-Id
+          required: true
+          description: Transaction origin (populated by APIM policy)
+          schema:
+            $ref: '#/components/schemas/SessionClientId'
+      responses:
+        '200':
+          description: Transaction id successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionGetTransactionIdResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '404':
+          description: Session or payment method not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '409':
+          description: Invalid session (no transaction associated or mismatched security token)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
+        '500':
+          description: Service unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemJson'
 components:
   schemas:
     PaymentMethodId:
@@ -656,6 +721,15 @@ components:
         transactionId:
           type: string
           description: Transaction ID to associate with the session
+    SessionGetTransactionIdResponse:
+      type: object
+      description: Transaction id for session successful response
+      required:
+        - transactionId
+      properties:
+        transactionId:
+          type: string
+          description: Transaction id associated to this NPG session
     SessionPaymentMethodResponse:
       type: object
       description: Session Payment method Response

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/exception/InvalidSessionException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/exception/InvalidSessionException.kt
@@ -1,0 +1,4 @@
+package it.pagopa.ecommerce.payment.methods.exception
+
+class InvalidSessionException(orderId: String) :
+    RuntimeException("Session for orderId [$orderId] has no associated transaction")

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/exception/MismatchedSecurityTokenException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/exception/MismatchedSecurityTokenException.kt
@@ -1,0 +1,6 @@
+package it.pagopa.ecommerce.payment.methods.exception
+
+class MismatchedSecurityTokenException(orderId: String, transactionId: String) :
+    RuntimeException(
+        "Invalid security token for orderId [$orderId], transactionId [$transactionId]"
+    )

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/resource/v1/PaymentMethodsHandlerResource.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/resource/v1/PaymentMethodsHandlerResource.kt
@@ -85,17 +85,20 @@ constructor(private val paymentMethodService: PaymentMethodService) : PaymentMet
         orderId: String,
         authorization: String,
         xClientId: @NotNull it.pagopa.ecommerce.payment.methods.v1.server.model.SessionClientId,
-    ): CompletionStage<it.pagopa.ecommerce.payment.methods.v1.server.model.SessionGetTransactionIdResponse> {
+    ): CompletionStage<
+        it.pagopa.ecommerce.payment.methods.v1.server.model.SessionGetTransactionIdResponse
+    > {
         val securityToken =
-            authorization
-                .takeIf { it.startsWith("Bearer ") }
-                ?.removePrefix("Bearer ")
-                ?: throw jakarta.validation.ValidationException("Missing or invalid Authorization Bearer token")
+            authorization.takeIf { it.startsWith("Bearer ") }?.removePrefix("Bearer ")
+                ?: throw jakarta.validation.ValidationException(
+                    "Missing or invalid Authorization Bearer token"
+                )
 
         return paymentMethodService
             .getTransactionIdForSession(id, orderId, securityToken, xClientId.toString())
             .map { transactionId ->
-                it.pagopa.ecommerce.payment.methods.v1.server.model.SessionGetTransactionIdResponse()
+                it.pagopa.ecommerce.payment.methods.v1.server.model
+                    .SessionGetTransactionIdResponse()
                     .apply { this.transactionId = transactionId }
             }
             .subscribeAsCompletionStage()
@@ -220,11 +223,7 @@ constructor(private val paymentMethodService: PaymentMethodService) : PaymentMet
         exception: it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException
     ): RestResponse<ProblemJson> {
         log.warn("Mismatched Security Token: {}", exception.message)
-        return problemResponse(
-            Response.Status.NOT_FOUND,
-            "Not Found",
-            "Order id not found",
-        )
+        return problemResponse(Response.Status.NOT_FOUND, "Not Found", "Order id not found")
     }
 
     private fun problemResponse(

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/resource/v1/PaymentMethodsHandlerResource.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/resource/v1/PaymentMethodsHandlerResource.kt
@@ -80,6 +80,27 @@ constructor(private val paymentMethodService: PaymentMethodService) : PaymentMet
             .subscribeAsCompletionStage()
     }
 
+    override fun getTransactionIdForSession(
+        id: String,
+        orderId: String,
+        authorization: String,
+        xClientId: @NotNull it.pagopa.ecommerce.payment.methods.v1.server.model.SessionClientId,
+    ): CompletionStage<it.pagopa.ecommerce.payment.methods.v1.server.model.SessionGetTransactionIdResponse> {
+        val securityToken =
+            authorization
+                .takeIf { it.startsWith("Bearer ") }
+                ?.removePrefix("Bearer ")
+                ?: throw jakarta.validation.ValidationException("Missing or invalid Authorization Bearer token")
+
+        return paymentMethodService
+            .getTransactionIdForSession(id, orderId, securityToken, xClientId.toString())
+            .map { transactionId ->
+                it.pagopa.ecommerce.payment.methods.v1.server.model.SessionGetTransactionIdResponse()
+                    .apply { this.transactionId = transactionId }
+            }
+            .subscribeAsCompletionStage()
+    }
+
     @ServerExceptionMapper
     fun mapNpgResponseException(exception: NpgResponseException): RestResponse<ProblemJson> {
         log.error("NPG Response Exception", exception)
@@ -179,6 +200,30 @@ constructor(private val paymentMethodService: PaymentMethodService) : PaymentMet
             Response.Status.CONFLICT,
             "Session already associated to transaction",
             exception.message.orEmpty(),
+        )
+    }
+
+    @ServerExceptionMapper
+    fun mapInvalidSessionException(
+        exception: it.pagopa.ecommerce.payment.methods.exception.InvalidSessionException
+    ): RestResponse<ProblemJson> {
+        log.info("Invalid Session: {}", exception.message)
+        return problemResponse(
+            Response.Status.CONFLICT,
+            "Invalid session",
+            exception.message.orEmpty(),
+        )
+    }
+
+    @ServerExceptionMapper
+    fun mapMismatchedSecurityTokenException(
+        exception: it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException
+    ): RestResponse<ProblemJson> {
+        log.warn("Mismatched Security Token: {}", exception.message)
+        return problemResponse(
+            Response.Status.NOT_FOUND,
+            "Not Found",
+            "Order id not found",
         )
     }
 

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodService.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodService.kt
@@ -39,4 +39,11 @@ interface PaymentMethodService {
         patchSessionRequest: PatchSessionRequest,
         xClientId: String,
     ): Uni<Void>
+
+    fun getTransactionIdForSession(
+        paymentMethodId: String,
+        orderId: String,
+        securityToken: String,
+        xClientId: String,
+    ): Uni<String>
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
@@ -9,9 +9,9 @@ import it.pagopa.ecommerce.payment.methods.client.PaymentMethodsClient
 import it.pagopa.ecommerce.payment.methods.config.SessionUrlConfig
 import it.pagopa.ecommerce.payment.methods.domain.CardDataDocument
 import it.pagopa.ecommerce.payment.methods.domain.NpgSessionDocument
-import it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException
 import it.pagopa.ecommerce.payment.methods.exception.InvalidSessionException
 import it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException
+import it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException
 import it.pagopa.ecommerce.payment.methods.exception.SessionAlreadyAssociatedToTransactionException
 import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionsRedisWrapper
 import it.pagopa.ecommerce.payment.methods.mappers.toPaymentMethodRequestDto
@@ -386,16 +386,11 @@ constructor(
             .flatMap { session ->
                 val transactionId = session!!.transactionId
                 if (transactionId == null) {
-                    Uni.createFrom()
-                        .failure(
-                            InvalidSessionException(orderId)
-                        )
+                    Uni.createFrom().failure(InvalidSessionException(orderId))
                 } else if (session.securityToken != securityToken) {
                     log.warn("Invalid security token for requested order id {}", orderId)
                     Uni.createFrom()
-                        .failure(
-                            MismatchedSecurityTokenException(orderId, transactionId)
-                        )
+                        .failure(MismatchedSecurityTokenException(orderId, transactionId))
                 } else {
                     Uni.createFrom().item(transactionId)
                 }

--- a/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImpl.kt
@@ -10,6 +10,8 @@ import it.pagopa.ecommerce.payment.methods.config.SessionUrlConfig
 import it.pagopa.ecommerce.payment.methods.domain.CardDataDocument
 import it.pagopa.ecommerce.payment.methods.domain.NpgSessionDocument
 import it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException
+import it.pagopa.ecommerce.payment.methods.exception.InvalidSessionException
+import it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException
 import it.pagopa.ecommerce.payment.methods.exception.SessionAlreadyAssociatedToTransactionException
 import it.pagopa.ecommerce.payment.methods.infrastructure.NpgSessionsRedisWrapper
 import it.pagopa.ecommerce.payment.methods.mappers.toPaymentMethodRequestDto
@@ -357,6 +359,45 @@ constructor(
                             transactionId = requestedTransactionId,
                         )
                     npgSessionsRedisWrapper.save(updatedDocument).replaceWithVoid()
+                }
+            }
+    }
+
+    override fun getTransactionIdForSession(
+        paymentMethodId: String,
+        orderId: String,
+        securityToken: String,
+        xClientId: String,
+    ): Uni<String> {
+        log.info(
+            "[Payment Method handler] Get transactionId for paymentMethodId: {} and orderId: {}",
+            paymentMethodId,
+            orderId,
+        )
+
+        val xRequestId = UUID.randomUUID().toString()
+
+        return restClient
+            .getPaymentMethod(paymentMethodId, xRequestId, xClientId)
+            .flatMap { npgSessionsRedisWrapper.findById(orderId) }
+            .onItem()
+            .ifNull()
+            .failWith { OrderIdNotFoundException(orderId) }
+            .flatMap { session ->
+                val transactionId = session!!.transactionId
+                if (transactionId == null) {
+                    Uni.createFrom()
+                        .failure(
+                            InvalidSessionException(orderId)
+                        )
+                } else if (session.securityToken != securityToken) {
+                    log.warn("Invalid security token for requested order id {}", orderId)
+                    Uni.createFrom()
+                        .failure(
+                            MismatchedSecurityTokenException(orderId, transactionId)
+                        )
+                } else {
+                    Uni.createFrom().item(transactionId)
                 }
             }
     }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
@@ -1066,4 +1066,88 @@ class PaymentMethodsClientTest {
 
         verify(mockNpgSessionsRedis, times(0)).findById(any())
     }
+
+    // --- getTransactionIdForSession tests ---
+
+    @Test
+    fun `should return transactionId when session is valid and token matches`() {
+        val sessionWithTransaction = testSessionDocument.copy(transactionId = "tx-001")
+
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().item(sessionWithTransaction))
+
+        val result =
+            service
+                .getTransactionIdForSession("pm-001", testOrderId, "npg-sec-token", "CHECKOUT")
+                .await()
+                .indefinitely()
+
+        assertEquals("tx-001", result)
+    }
+
+    @Test
+    fun `should throw InvalidSessionException when session has no transactionId`() {
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().item(testSessionDocument))
+
+        assertThrows<it.pagopa.ecommerce.payment.methods.exception.InvalidSessionException> {
+            service
+                .getTransactionIdForSession("pm-001", testOrderId, "npg-sec-token", "CHECKOUT")
+                .await()
+                .indefinitely()
+        }
+    }
+
+    @Test
+    fun `should throw MismatchedSecurityTokenException when token does not match`() {
+        val sessionWithTransaction = testSessionDocument.copy(transactionId = "tx-001")
+
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().item(sessionWithTransaction))
+
+        assertThrows<it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException> {
+            service
+                .getTransactionIdForSession("pm-001", testOrderId, "wrong-token", "CHECKOUT")
+                .await()
+                .indefinitely()
+        }
+    }
+
+    @Test
+    fun `should throw OrderIdNotFoundException when session not found for getTransactionId`() {
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
+        whenever(mockNpgSessionsRedis.findById(testOrderId))
+            .thenReturn(Uni.createFrom().nullItem())
+
+        assertThrows<it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException> {
+            service
+                .getTransactionIdForSession("pm-001", testOrderId, "npg-sec-token", "CHECKOUT")
+                .await()
+                .indefinitely()
+        }
+    }
+
+    @Test
+    fun `should throw PaymentMethodNotFoundException when payment method does not exist for getTransactionId`() {
+        whenever(mockClient.getPaymentMethod(any(), any(), any()))
+            .thenReturn(
+                Uni.createFrom().failure(PaymentMethodNotFoundException("Payment method not found"))
+            )
+
+        assertThrows<PaymentMethodNotFoundException> {
+            service
+                .getTransactionIdForSession("pm-001", testOrderId, "npg-sec-token", "CHECKOUT")
+                .await()
+                .indefinitely()
+        }
+
+        verify(mockNpgSessionsRedis, times(0)).findById(any())
+    }
 }

--- a/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
+++ b/src/test/kotlin/it/pagopa/ecommerce/payment/methods/services/PaymentMethodServiceImplTest.kt
@@ -1111,7 +1111,9 @@ class PaymentMethodsClientTest {
         whenever(mockNpgSessionsRedis.findById(testOrderId))
             .thenReturn(Uni.createFrom().item(sessionWithTransaction))
 
-        assertThrows<it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException> {
+        assertThrows<
+            it.pagopa.ecommerce.payment.methods.exception.MismatchedSecurityTokenException
+        > {
             service
                 .getTransactionIdForSession("pm-001", testOrderId, "wrong-token", "CHECKOUT")
                 .await()
@@ -1123,8 +1125,7 @@ class PaymentMethodsClientTest {
     fun `should throw OrderIdNotFoundException when session not found for getTransactionId`() {
         whenever(mockClient.getPaymentMethod(any(), any(), any()))
             .thenReturn(Uni.createFrom().item(buildAfmPaymentMethodResponse()))
-        whenever(mockNpgSessionsRedis.findById(testOrderId))
-            .thenReturn(Uni.createFrom().nullItem())
+        whenever(mockNpgSessionsRedis.findById(testOrderId)).thenReturn(Uni.createFrom().nullItem())
 
         assertThrows<it.pagopa.ecommerce.payment.methods.exception.OrderIdNotFoundException> {
             service


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Migrated `getTransactionIdForSession` endpoint from pagopa-ecommerce-payment-methods-service (Java/Spring) to this handler (Kotlin/Quarkus)
- Added `GET /payment-methods/{id}/sessions/{orderId}/transactionId` endpoint schema to the OpenAPI spec

#### Motivation and Context

This PR continues the migration from `pagopa-ecommerce-payment-methods-service` into this `handler`, involving the `getTransactionIdForSession` endpoint.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.